### PR TITLE
macOS: Set up latest Homebrew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,11 @@ jobs:
           echo "INSTALL_DIR=/opt/olive-editor" >> $GITHUB_ENV
           echo -e "/opt/olive-editor\n/opt/olive-editor/lib\n/opt/olive-editor/include\n$(cat $GITHUB_PATH)" > $GITHUB_PATH
 
+      # HACK: Don't use pre-installed Homebrew 3.0.10 from GitHub's virtual environment
+      # Newer versions download packages from GitHub instead of Bintray which is shutting down
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: Install Ninja
         shell: bash
         run: |


### PR DESCRIPTION
Bintray is shutting down, Homebrew 3.1+ downloads from GitHub Packages instead.

https://github.com/Homebrew/discussions/discussions/691#discussioncomment-600559